### PR TITLE
add possibility to encode POST arguments as JSON body

### DIFF
--- a/httprpc-client/src/main/java/org/httprpc/RequestEncoding.java
+++ b/httprpc-client/src/main/java/org/httprpc/RequestEncoding.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.httprpc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that associates an request encoding with a service method.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface RequestEncoding {
+    /**
+     * @return
+     * The request encoding associated with the method.
+     */
+    WebServiceProxy.Encoding value();
+}


### PR DESCRIPTION
Hi Greg,
fist of all thanks for sharing this great code!

The HTTP RPC server I'm trying to communicate with requires the POST arguments encoded as JSON in the request body.

Thus, it was required to specify request handlers as follows:
`webServiceProxy.setRequestHandler(x -> {
                JSONEncoder jsonEncoder = new JSONEncoder();
                jsonEncoder.write(Map.of("asd", "wer"), x);
});`

...which is kind of complicated and I really liked your idea of the Typed Access via `WebServiceProxy.adapt(...`, so I did some slight changes to your code to allow JSON encoded request bodies.

I'm looking forward to a quick merge, so I can use the fix in my projects!

Thanks!